### PR TITLE
Various fixes to help CTS to pass

### DIFF
--- a/lib/codecs/gsth264decoder.c
+++ b/lib/codecs/gsth264decoder.c
@@ -1341,6 +1341,9 @@ gst_h264_decoder_decode_nal (GstH264Decoder * self, GstH264NalUnit * nalu)
       nalu->type, nalu->offset, nalu->size);
 
   switch (nalu->type) {
+    case GST_H264_NAL_SEI:
+      GST_DEBUG_OBJECT(self, "Received a SEI nal");
+      break;
     case GST_H264_NAL_SPS:
       ret = gst_h264_decoder_parse_sps (self, nalu);
       break;

--- a/lib/gstvkvideoparser.cpp
+++ b/lib/gstvkvideoparser.cpp
@@ -115,6 +115,7 @@ bool GstVkVideoParser::Build ()
     decoder = gst_element_factory_make_full("vkh264parse", "user-data", m_user_data,
         "oob-pic-params",  m_oob_pic_params, NULL);
     g_assert (decoder);
+    g_object_set(decoder, "compliance", 3, NULL);
   } else if (m_codec == VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT) {
     parser_name = "h265parse";
     src_caps_desc = "video/x-h265,stream-format=byte-stream";
@@ -149,7 +150,7 @@ bool GstVkVideoParser::Build ()
 
   gst_object_unref (bin);
 
-  gst_harness_set_live (m_parser, FALSE);
+  gst_harness_set_live (m_parser, TRUE);
 
   gst_harness_set_src_caps_str (m_parser,
       src_caps_desc);


### PR DESCRIPTION
This is an ongoing work to fix the use of GstVkVideoParser in vk-gl-cts