### PR TITLE
Various memory management issue

### DIFF
--- a/plugins/gstvkh265dec.cpp
+++ b/plugins/gstvkh265dec.cpp
@@ -114,6 +114,8 @@ vk_pic_free (gpointer data)
   if (vkpic->pic)
     vkpic->pic->Release ();
   g_byte_array_unref (vkpic->bitstream);
+  g_free ((uint32_t *)vkpic->data.pSliceDataOffsets);
+  g_free (vkpic->data.pBitstreamData);
   g_array_unref (vkpic->slice_offsets);
   g_free (vkpic->slice_group_map);
   g_free (vkpic);
@@ -313,12 +315,11 @@ gst_vk_h265_dec_end_picture (GstH265Decoder * decoder, GstH265Picture * picture)
   GstVkH265Dec *self = GST_VK_H265_DEC (decoder);
   VkPic *vkpic = reinterpret_cast<VkPic *>(gst_h265_picture_get_user_data(picture));
   gsize len;
-  uint32_t *slice_offsets;
   GstFlowReturn ret = GST_FLOW_OK;
 
   vkpic->data.pBitstreamData = g_byte_array_steal (vkpic->bitstream, &len);
   vkpic->data.nBitstreamDataLen = static_cast<int32_t>(len);
-  vkpic->data.pSliceDataOffsets = slice_offsets =
+  vkpic->data.pSliceDataOffsets =
       static_cast <uint32_t *>(g_array_steal (vkpic->slice_offsets, NULL));
 
   // FIXME: This flag is set to TRUE unconditionally because VulkanVideoParser.cpp expects it be true
@@ -330,9 +331,6 @@ gst_vk_h265_dec_end_picture (GstH265Decoder * decoder, GstH265Picture * picture)
     if (!self->client->DecodePicture (&vkpic->data))
       ret = GST_FLOW_ERROR;
   }
-
-  g_free (vkpic->data.pBitstreamData);
-  g_free (slice_offsets);
 
   return ret;
 }

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -149,6 +149,7 @@ int main(int argc, char** argv)
 
     if (codec_str && strcmp (codec_str, "h265") == 0)
       codec = VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT;
+    g_free (codec_str);
 
     int num = g_strv_length (filenames);
     for (int i = 0; i < num; ++i)


### PR DESCRIPTION
commit 5bd036a5fb0a9908dfdbc87529bf9051f4406e2a (HEAD -> dab_fix_memory_usage, dabrain34/dab_fix_memory_usage)
Author: Stéphane Cerveau <scerveau@igalia.com>
Date:   Thu Nov 10 15:58:50 2022 +0100

    vkh26xdec: destroy the vkPic data when the GstH26xPicture is released
    
    It avoids VK_ERROR_DEVICE_LOST in some CTS decode tests

commit 2f80972a7c3cf4655f42b1b7dcceb4f41213832e
Author: Stéphane Cerveau <scerveau@igalia.com>
Date:   Thu Nov 10 15:59:02 2022 +0100

    test: free codec_str
