### PR TITLE
demuxeres: use parsebin instead of uridecodebin

### DIFF
--- a/lib/demuxeres/gstdemuxeres.c
+++ b/lib/demuxeres/gstdemuxeres.c
@@ -504,12 +504,19 @@ handle_bus_message (GstBus * bus, GstMessage * message, GstDemuxerES * demuxer)
   switch (GST_MESSAGE_TYPE (message)) {
     case GST_MESSAGE_ERROR:
     {
-      set_demuxer_state (demuxer, DEMUXER_ES_STATE_ERROR);;
+      set_demuxer_state (demuxer, DEMUXER_ES_STATE_ERROR);
       break;
     }
     case GST_MESSAGE_EOS:
     {
-      set_demuxer_state (demuxer, DEMUXER_ES_STATE_EOS);;
+      set_demuxer_state (demuxer, DEMUXER_ES_STATE_EOS);
+      break;
+    }
+    // parsebin does not trigger 'no-more-pads' with elementary stream, rely on stream-collection event instead
+    // See https://gitlab.freedesktop.org/gstreamer/gstreamer/-/issues/2119
+    case GST_MESSAGE_STREAM_COLLECTION:
+    {
+      set_demuxer_state (demuxer, DEMUXER_ES_STATE_READY);
       break;
     }
     case GST_MESSAGE_ELEMENT:


### PR DESCRIPTION
This MR intends to remove uridecodebin because we discover a limitation of uridecodebin when no decoder is available. In that case uridecodebin does not expose the pad if not decoder can be found for the given mimetype.
Parsebin is having the same limitation but a patch has been issued upstream to address this issue.

See https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/4121

See also https://gitlab.freedesktop.org/gstreamer/gstreamer/-/issues/2119 for the no-more-pads design issue discussion