### PR TITLE
h26xdec: Skip access unit delimiters

### DIFF
--- a/lib/codecs/gsth264decoder.c
+++ b/lib/codecs/gsth264decoder.c
@@ -1358,6 +1358,8 @@ gst_h264_decoder_decode_nal (GstH264Decoder * self, GstH264NalUnit * nalu)
     case GST_H264_NAL_SLICE_EXT:
       ret = gst_h264_decoder_parse_slice (self, nalu);
       break;
+    case GST_H264_NAL_AU_DELIMITER:
+      break; // skip
     default:
       if (klass->unhandled_nalu)
         klass->unhandled_nalu (self, nalu->data + nalu->offset, nalu->size);

--- a/lib/codecs/gsth265decoder.c
+++ b/lib/codecs/gsth265decoder.c
@@ -856,6 +856,8 @@ gst_h265_decoder_parse_nalu (GstH265Decoder * self, GstH265NalUnit * nalu)
     case GST_H265_NAL_EOS:
       priv->prev_nal_is_eos = TRUE;
       break;
+    case GST_H265_NAL_AUD:
+      break; // Skip
     default:
       if (klass->unhandled_nalu)
         klass->unhandled_nalu (self, nalu->data + nalu->offset, nalu->size);

--- a/samples/Sample_10.avc.ref
+++ b/samples/Sample_10.avc.ref
@@ -127,7 +127,6 @@ UpdatePictureParameters
     },
     "updateSequenceCount": 0,
 },
-UnhandledNALU
 UpdatePictureParameters
 "VkPictureParameters": {
     "StdVideoH264SequenceParameterSet": {
@@ -543,7 +542,6 @@ DecodePicture - 1145
     },
     "current_dpb_id": 0,
 },
-UnhandledNALU
 AllocPictureBuffer
 DecodePicture - 731
 "VkParserPictureData": {
@@ -867,7 +865,6 @@ DecodePicture - 731
 },
 DisplayPicture
 DisplayPicture
-UnhandledNALU
 AllocPictureBuffer
 DecodePicture - 544
 "VkParserPictureData": {
@@ -1195,7 +1192,6 @@ DecodePicture - 544
     "current_dpb_id": 0,
 },
 DisplayPicture
-UnhandledNALU
 AllocPictureBuffer
 DecodePicture - 515
 "VkParserPictureData": {
@@ -1528,7 +1524,6 @@ DecodePicture - 515
     "current_dpb_id": 0,
 },
 DisplayPicture
-UnhandledNALU
 AllocPictureBuffer
 DecodePicture - 380
 "VkParserPictureData": {
@@ -1861,7 +1856,6 @@ DecodePicture - 380
     "current_dpb_id": 0,
 },
 DisplayPicture
-UnhandledNALU
 AllocPictureBuffer
 DecodePicture - 363
 "VkParserPictureData": {
@@ -2194,7 +2188,6 @@ DecodePicture - 363
     "current_dpb_id": 0,
 },
 DisplayPicture
-UnhandledNALU
 AllocPictureBuffer
 DecodePicture - 339
 "VkParserPictureData": {
@@ -2527,7 +2520,6 @@ DecodePicture - 339
     "current_dpb_id": 0,
 },
 DisplayPicture
-UnhandledNALU
 AllocPictureBuffer
 DecodePicture - 281
 "VkParserPictureData": {
@@ -2860,7 +2852,6 @@ DecodePicture - 281
     "current_dpb_id": 0,
 },
 DisplayPicture
-UnhandledNALU
 AllocPictureBuffer
 DecodePicture - 346
 "VkParserPictureData": {
@@ -3193,7 +3184,6 @@ DecodePicture - 346
     "current_dpb_id": 0,
 },
 DisplayPicture
-UnhandledNALU
 AllocPictureBuffer
 DecodePicture - 376
 "VkParserPictureData": {

--- a/samples/Sample_10.hevc.ref
+++ b/samples/Sample_10.hevc.ref
@@ -260,7 +260,6 @@ BeginSequence
     "cbSideData": 0,
     "codecProfile": 1,
 },
-UnhandledNALU
 UpdatePictureParameters
 "VkPictureParameters": {
     "StdVideoH265VideoParameterSet": {
@@ -1113,7 +1112,6 @@ DecodePicture - 1920
     "current_dpb_id": 0,
 },
 DisplayPicture
-UnhandledNALU
 AllocPictureBuffer
 DecodePicture - 544
 "VkParserPictureData": {
@@ -1590,7 +1588,6 @@ DecodePicture - 544
     "current_dpb_id": 0,
 },
 DisplayPicture
-UnhandledNALU
 AllocPictureBuffer
 DecodePicture - 505
 "VkParserPictureData": {
@@ -2072,7 +2069,6 @@ DecodePicture - 505
     "current_dpb_id": 0,
 },
 DisplayPicture
-UnhandledNALU
 AllocPictureBuffer
 DecodePicture - 466
 "VkParserPictureData": {
@@ -2559,7 +2555,6 @@ DecodePicture - 466
     "current_dpb_id": 0,
 },
 DisplayPicture
-UnhandledNALU
 AllocPictureBuffer
 DecodePicture - 350
 "VkParserPictureData": {
@@ -3051,7 +3046,6 @@ DecodePicture - 350
     "current_dpb_id": 0,
 },
 DisplayPicture
-UnhandledNALU
 AllocPictureBuffer
 DecodePicture - 302
 "VkParserPictureData": {
@@ -3543,7 +3537,6 @@ DecodePicture - 302
     "current_dpb_id": 0,
 },
 DisplayPicture
-UnhandledNALU
 AllocPictureBuffer
 DecodePicture - 313
 "VkParserPictureData": {
@@ -4035,7 +4028,6 @@ DecodePicture - 313
     "current_dpb_id": 0,
 },
 DisplayPicture
-UnhandledNALU
 AllocPictureBuffer
 DecodePicture - 254
 "VkParserPictureData": {
@@ -4527,7 +4519,6 @@ DecodePicture - 254
     "current_dpb_id": 0,
 },
 DisplayPicture
-UnhandledNALU
 AllocPictureBuffer
 DecodePicture - 290
 "VkParserPictureData": {
@@ -5019,7 +5010,6 @@ DecodePicture - 290
     "current_dpb_id": 0,
 },
 DisplayPicture
-UnhandledNALU
 AllocPictureBuffer
 DecodePicture - 311
 "VkParserPictureData": {


### PR DESCRIPTION
Follows the same pattern as VAAPI. For h.264, according to 7.4.2.4, this isn't a normative part of the bitstream, but there to simplify the detection of boundaries between access units. Not required for the CTS. Ditto for 265.